### PR TITLE
update Table._free to use autocommit check

### DIFF
--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -1362,7 +1362,8 @@ class Table(object):
         if self._handle is None:
             raise IPTCError("table is not initialized")
         try:
-            self.commit()
+            if self.autocommit:
+                self.commit()
         except IPTCError, e:
             if not ignore_exc:
                 raise e


### PR DESCRIPTION
`Table._free` method does not check for autocommit. When object goes out of scope `Table.__del__` is called => calls close method => calls `Table._free` => causes commit irrespective of whether user has set `autocommit = True` or not. This patch checks for `self.autocommit` during `_free` to prevent commits from happening when autocommit is False.
