### PR TITLE
Replace assertIn() with assertTrue().

### DIFF
--- a/iptc/test/test_matches.py
+++ b/iptc/test/test_matches.py
@@ -294,7 +294,7 @@ class TestXTStateMatch(unittest.TestCase):
         self.chain.insert_rule(self.rule)
         rule = self.chain.rules[0]
         m = rule.matches[0]
-        self.assertIn(m.name, ["state", "conntrack"])
+        self.assertTrue(m.name, ["state", "conntrack"])
         self.assertEquals(m.state, "RELATED,ESTABLISHED")
 
 

--- a/iptc/test/test_targets.py
+++ b/iptc/test/test_targets.py
@@ -368,7 +368,7 @@ class TestXTNotrackTarget(unittest.TestCase):
     def test_notrack(self):
         self.chain.insert_rule(self.rule)
         t = self.chain.rules[0].target
-        self.assertIn(t.name, ["NOTRACK", "CT"])
+        self.assertTrue(t.name in ["NOTRACK", "CT"])
 
 
 def suite():


### PR DESCRIPTION
Unittest in Python 2.6 does not have assertIn().
