### PR TITLE
Fix return and argument types for various libiptc API calls.

### DIFF
--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -103,7 +103,7 @@ _libiptc, _ = find_library("ip4tc", "iptc")  # old iptables versions use iptc
 class iptc(object):
     """This class contains all libiptc API calls."""
     iptc_init = _libiptc.iptc_init
-    iptc_init.restype = ct.c_void_p
+    iptc_init.restype = ct.POINTER(ct.c_int)
     iptc_init.argstype = [ct.c_char_p]
 
     iptc_free = _libiptc.iptc_free
@@ -120,11 +120,11 @@ class iptc(object):
 
     iptc_first_chain = _libiptc.iptc_first_chain
     iptc_first_chain.restype = ct.c_char_p
-    iptc_first_chain.argstype = [ct.c_char_p, ct.c_void_p]
+    iptc_first_chain.argstype = [ct.c_void_p]
 
     iptc_next_chain = _libiptc.iptc_next_chain
     iptc_next_chain.restype = ct.c_char_p
-    iptc_next_chain.argstype = [ct.c_char_p, ct.c_void_p]
+    iptc_next_chain.argstype = [ct.c_void_p]
 
     iptc_is_chain = _libiptc.iptc_is_chain
     iptc_is_chain.restype = ct.c_int

--- a/iptc/ip6tc.py
+++ b/iptc/ip6tc.py
@@ -82,7 +82,7 @@ _libiptc, _ = find_library("ip6tc", "iptc")  # old iptables versions use iptc
 class ip6tc(object):
     """This class contains all libip6tc API calls."""
     iptc_init = _libiptc.ip6tc_init
-    iptc_init.restype = ct.c_void_p
+    iptc_init.restype = ct.POINTER(ct.c_int)
     iptc_init.argstype = [ct.c_char_p]
 
     iptc_free = _libiptc.ip6tc_free
@@ -99,11 +99,11 @@ class ip6tc(object):
 
     iptc_first_chain = _libiptc.ip6tc_first_chain
     iptc_first_chain.restype = ct.c_char_p
-    iptc_first_chain.argstype = [ct.c_char_p, ct.c_void_p]
+    iptc_first_chain.argstype = [ct.c_void_p]
 
     iptc_next_chain = _libiptc.ip6tc_next_chain
     iptc_next_chain.restype = ct.c_char_p
-    iptc_next_chain.argstype = [ct.c_char_p, ct.c_void_p]
+    iptc_next_chain.argstype = [ct.c_void_p]
 
     iptc_is_chain = _libiptc.ip6tc_is_chain
     iptc_is_chain.restype = ct.c_int


### PR DESCRIPTION
Specifically without the iptc_init restype change python-iptables segfaults on hardened systems running PaX-enabled kernels.
