### PR TITLE
Flush stdout to avoid getting buffered results.

### DIFF
--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 import ctypes as ct
 import socket
 import struct
@@ -294,6 +295,8 @@ class IPTCModule(object):
 
         # redirect C stdout to a pipe and read back the output of m->save
 
+        # Flush stdout to avoid getting buffered results
+        sys.stdout.flush()
         # Save the current C stdout.
         stdout = os.dup(1)
         try:


### PR DESCRIPTION
I am currently using python-iptable in a worker launched by supervisor. The worker is writing on stdout and when i am reading rules, i am get an invalid result (incomplete rules). Launching the worker without supervisor is working fine.

This worked fine for me before c0f40e6952f98001633bf2536b398bb78db9d8b9.

I investigated and found out that the stdout was no longer flushed, and i was getting the previously printed result.
