### PR TITLE
Updates to allow some tests to pass with Python 3.

### DIFF
--- a/iptc/ip6tc.py
+++ b/iptc/ip6tc.py
@@ -266,7 +266,7 @@ class Rule6(Rule):
         return bits
 
     def _create_mask(self, plen):
-        mask = [0 for x in xrange(16)]
+        mask = [0 for x in range(16)]
         i = 0
         while plen > 0:
             if plen >= 8:
@@ -558,15 +558,15 @@ class Table6(Table):
     low-level details from the user.
     """
 
-    FILTER = b"filter"
+    FILTER = "filter"
     """This is the constant for the filter table."""
-    MANGLE = b"mangle"
+    MANGLE = "mangle"
     """This is the constant for the mangle table."""
-    RAW = b"raw"
+    RAW = "raw"
     """This is the constant for the raw table."""
-    SECURITY = b"security"
+    SECURITY = "security"
     """This is the constant for the security table."""
-    ALL = [b"filter", b"mangle", b"raw", b"security"]
+    ALL = ["filter", "mangle", "raw", "security"]
     """This is the constant for all tables."""
 
     _cache = dict()

--- a/iptc/test/test_iptc.py
+++ b/iptc/test/test_iptc.py
@@ -288,7 +288,7 @@ class TestChain(unittest.TestCase):
         for chain in (chain for table in tables for chain in table.chains):
             counters = chain.get_counters()
             fails = 0
-            for x in xrange(3):  # try 3 times
+            for x in range(3):  # try 3 times
                 chain.zero_counters()
                 counters = chain.get_counters()
                 if counters:   # only built-in chains

--- a/iptc/xtables.py
+++ b/iptc/xtables.py
@@ -787,8 +787,8 @@ class xtables(object):
         self.proto = proto
         self._xt_globals = xtables_globals()
         self._xt_globals.option_offset = 0
-        self._xt_globals.program_name = version.__pkgname__
-        self._xt_globals.program_version = version.__version__
+        self._xt_globals.program_name = version.__pkgname__.encode()
+        self._xt_globals.program_version = version.__version__.encode()
         self._xt_globals.orig_opts = None
         self._xt_globals.opts = None
         self._xt_globals.exit_err = _xt_exit
@@ -913,10 +913,10 @@ class xtables(object):
     @preserve_globals
     def find_target(self, name):
         name = self._check_extname(name)
-        target = xtables._xtables_find_target(name, XTF_TRY_LOAD)
+        target = xtables._xtables_find_target(name.encode(), XTF_TRY_LOAD)
         if not target:
             self._try_register(name)
-            target = xtables._xtables_find_target(name, XTF_TRY_LOAD)
+            target = xtables._xtables_find_target(name.encode(), XTF_TRY_LOAD)
             if not target:
                 return target
         self._loaded(name)


### PR DESCRIPTION
This patch allows some of the tests to pass when using python-iptables in Python 3.  This patch doesn't allow all the tests to pass, but I'm stuck fixing some of the issues.  I'm sharing this pull request in case someone else wants to start working on this.

The basic issue I've found is dealing with bytes vs. str.  The code is inconsistent in dealing with these types and as a result comparisons with str values throughout the code fail.  I've tried to make it consistent where all text is an str within the module.  Bytes are converted to str when taken from the C library or coverted to bytes when passed to C.
