### PR TITLE
Fix empty buffer case in get_all_parameters().

### DIFF
--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -372,6 +372,8 @@ class IPTCModule(object):
         buf = self._get_saved_buf(ip)
         if buf is not None:
             res = shlex.split(buf)
+            if len(res) == 0:
+                return params
             key, p = res[0], res[1:]
             if len(p) == 1:
                p = p[0]


### PR DESCRIPTION
Return empty dict if the iptables buffer is empty in
get_all_parameters().
