### PR TITLE
Fix: retrieve library extension

### DIFF
--- a/iptc/util.py
+++ b/iptc/util.py
@@ -70,9 +70,10 @@ def _do_find_library(name):
 
 
 def _find_library(*names):
-    ext = get_config_var('SO')
-    if version_info > (3, ) and version_info < (3, 4):
-        ext = '.cpython-%i%i' % (version_info.major, version_info.minor) + ext
+    if version_info > (3, ):
+        ext = get_config_var("EXT_SUFFIX")
+    else:
+        ext = get_config_var('SO')
     for name in names:
         for n in (name, "lib" + name, name + ext, "lib" + name + ext):
             lib = _do_find_library(n)


### PR DESCRIPTION
Fix #139.
* python2 uses get_config_var('SO')
* python3 uses get_config_var('EXT_CONFIG')