### PR TITLE
Don't try to load kernel modules unless they are supported

### DIFF
--- a/iptc/util.py
+++ b/iptc/util.py
@@ -23,6 +23,10 @@ def _insert_ko(modprobe, modname):
 
 
 def _load_ko(modname):
+    # only try to load modules on kernels that support them
+    if not os.path.exists("/proc/modules"):
+        return (0, None)
+
     # this will return the full path for the modprobe binary
     modprobe = "/sbin/modprobe"
     try:


### PR DESCRIPTION
Currently the code will try to load kernel modules even if they are not supported by the kernel, and bomb out. This checks if modules are supported first.