### PR TITLE
add xtables v11 match and target

### DIFF
--- a/iptc/xtables.py
+++ b/iptc/xtables.py
@@ -108,6 +108,10 @@ class xt_option_entry(ct.Structure):
                 ("max", ct.c_uint)]
 
 
+class xt_xlate(ct.Structure):
+    _fields_ = []
+
+
 class _U1(ct.Union):
     _fields_ = [("match", ct.POINTER(ct.POINTER(xt_entry_match))),
                 ("target", ct.POINTER(ct.POINTER(xt_entry_target)))]
@@ -408,6 +412,62 @@ class _xtables_match_v10(ct.Structure):
                 ("loaded", ct.c_uint)]
 
 
+class _xtables_match_v11(ct.Structure):
+    _fields_ = [("version", ct.c_char_p),
+                ("next", ct.c_void_p),
+                ("name", ct.c_char_p),
+                ("real_name", ct.c_char_p),
+                ("revision", ct.c_uint8),
+                ("ext_flags", ct.c_uint8),
+                ("family", ct.c_uint16),
+                ("size", ct.c_size_t),
+                ("userspacesize", ct.c_size_t),
+                ("help", ct.CFUNCTYPE(None)),
+                ("init", ct.CFUNCTYPE(None, ct.POINTER(xt_entry_match))),
+                # fourth parameter entry is struct ipt_entry for example
+                # int (*parse)(int c, char **argv, int invert, unsigned int
+                # *flags, const void *entry, struct xt_entry_match **match)
+                ("parse", ct.CFUNCTYPE(ct.c_int, ct.c_int,
+                                       ct.POINTER(ct.c_char_p), ct.c_int,
+                                       ct.POINTER(ct.c_uint), ct.c_void_p,
+                                       ct.POINTER(ct.POINTER(
+                                           xt_entry_match)))),
+                ("final_check", ct.CFUNCTYPE(None, ct.c_uint)),
+                # prints out the match iff non-NULL: put space at end
+                # first parameter ip is struct ipt_ip * for example
+                ("print", ct.CFUNCTYPE(None, ct.c_void_p,
+                                       ct.POINTER(xt_entry_match), ct.c_int)),
+                # saves the match info in parsable form to stdout.
+                # first parameter ip is struct ipt_ip * for example
+                ("save", ct.CFUNCTYPE(None, ct.c_void_p,
+                                      ct.POINTER(xt_entry_match))),
+                # Print match name or alias
+                ("alias", ct.CFUNCTYPE(ct.c_char_p,
+                                       ct.POINTER(xt_entry_match))),
+                # pointer to list of extra command-line options
+                ("extra_opts", ct.POINTER(option)),
+
+                # introduced with the new iptables API
+                ("x6_parse", ct.CFUNCTYPE(None, ct.POINTER(xt_option_call))),
+                ("x6_fcheck", ct.CFUNCTYPE(None, ct.POINTER(xt_fcheck_call))),
+                ("x6_options", ct.POINTER(xt_option_entry)),
+
+                # Translate iptables to nft
+                ("xlate", ct.CFUNCTYPE(None, ct.c_void_p,
+                                       ct.POINTER(xt_entry_match),
+                                       ct.POINTER(xt_xlate), ct.c_int)),
+
+                # size of per-extension instance extra "global" scratch space
+                ("udata_size", ct.c_size_t),
+
+                # ignore these men behind the curtain:
+                ("udata", ct.c_void_p),
+                ("option_offset", ct.c_uint),
+                ("m", ct.POINTER(xt_entry_match)),
+                ("mflags", ct.c_uint),
+                ("loaded", ct.c_uint)]
+
+
 class xtables_match(ct.Union):
     _fields_ = [("v1", _xtables_match_v1),
                 ("v2", _xtables_match_v2),
@@ -418,7 +478,8 @@ class xtables_match(ct.Union):
                 ("v7", _xtables_match_v7),
                 # Apparently v8 was skipped
                 ("v9", _xtables_match_v9),
-                ("v10", _xtables_match_v10)]
+                ("v10", _xtables_match_v10),
+                ("v11", _xtables_match_v11)]
 
 
 class _xtables_target_v1(ct.Structure):
@@ -659,6 +720,64 @@ class _xtables_target_v10(ct.Structure):
                 ("loaded", ct.c_uint)]
 
 
+class _xtables_target_v11(ct.Structure):
+    _fields_ = [("version", ct.c_char_p),
+                ("next", ct.c_void_p),
+                ("name", ct.c_char_p),
+                ("real_name", ct.c_char_p),
+                ("revision", ct.c_uint8),
+                ("ext_flags", ct.c_uint8),
+                ("family", ct.c_uint16),
+                ("size", ct.c_size_t),
+                ("userspacesize", ct.c_size_t),
+                ("help", ct.CFUNCTYPE(None)),
+                ("init", ct.CFUNCTYPE(None, ct.POINTER(xt_entry_target))),
+                # fourth parameter entry is struct ipt_entry for example
+                # int (*parse)(int c, char **argv, int invert,
+                #              unsigned int *flags, const void *entry,
+                #              struct xt_entry_target **target)
+                ("parse", ct.CFUNCTYPE(ct.c_int,
+                                       ct.POINTER(ct.c_char_p), ct.c_int,
+                                       ct.POINTER(ct.c_uint), ct.c_void_p,
+                                       ct.POINTER(ct.POINTER(
+                                           xt_entry_target)))),
+                ("final_check", ct.CFUNCTYPE(None, ct.c_uint)),
+                # prints out the target iff non-NULL: put space at end
+                # first parameter ip is struct ipt_ip * for example
+                ("print", ct.CFUNCTYPE(None, ct.c_void_p,
+                                       ct.POINTER(xt_entry_target), ct.c_int)),
+                # saves the target info in parsable form to stdout.
+                # first parameter ip is struct ipt_ip * for example
+                ("save", ct.CFUNCTYPE(None, ct.c_void_p,
+                                      ct.POINTER(xt_entry_target))),
+                # Print target name or alias
+                ("alias", ct.CFUNCTYPE(ct.c_char_p,
+                                       ct.POINTER(xt_entry_target))),
+                # pointer to list of extra command-line options
+                ("extra_opts", ct.POINTER(option)),
+
+                # introduced with the new iptables API
+                ("x6_parse", ct.CFUNCTYPE(None, ct.POINTER(xt_option_call))),
+                ("x6_fcheck", ct.CFUNCTYPE(None, ct.POINTER(xt_fcheck_call))),
+                ("x6_options", ct.POINTER(xt_option_entry)),
+
+                # Translate iptables to nft
+                ("xlate", ct.CFUNCTYPE(None, ct.c_void_p,
+                                       ct.POINTER(xt_entry_match),
+                                       ct.POINTER(xt_xlate), ct.c_int)),
+
+                # size of per-extension instance extra "global" scratch space
+                ("udata_size", ct.c_size_t),
+
+                # ignore these men behind the curtain:
+                ("udata", ct.c_void_p),
+                ("option_offset", ct.c_uint),
+                ("t", ct.POINTER(xt_entry_target)),
+                ("tflags", ct.c_uint),
+                ("used", ct.c_uint),
+                ("loaded", ct.c_uint)]
+
+
 class xtables_target(ct.Union):
     _fields_ = [("v1", _xtables_target_v1),
                 ("v2", _xtables_target_v2),
@@ -669,7 +788,8 @@ class xtables_target(ct.Union):
                 ("v7", _xtables_target_v7),
                 # Apparently v8 was skipped
                 ("v9", _xtables_target_v9),
-                ("v10", _xtables_target_v10)]
+                ("v10", _xtables_target_v10),
+                ("v11", _xtables_target_v11)]
 
 
 class XTablesError(Exception):


### PR DESCRIPTION
This seems to enable basic compatibility with xtables v11. I tested normal function (adding targets and matches, purging tables, etc) and it seems to work fine. No idea about how it works with the new things added in iptables 1.6.0...