### PR TITLE
Fix mask computation for v6 IPs

### DIFF
--- a/iptc/ip6tc.py
+++ b/iptc/ip6tc.py
@@ -273,7 +273,7 @@ class Rule6(Rule):
             if plen >= 8:
                 mask.append(0xff)
             elif plen > 0:
-                mask.append(2 ** plen - 1)
+                mask.append(0xff>>(8-plen)<<(8-plen))
             else:
                 mask.append(0x00)
             plen -= 8

--- a/tests/test_iptc.py
+++ b/tests/test_iptc.py
@@ -374,6 +374,21 @@ class TestRule6(unittest.TestCase):
         self.chain.flush()
         self.chain.delete()
 
+    def test_create_mask(self):
+        rule = iptc.Rule6()
+
+        # Mask /10 should return \xff\xc0\x00...
+        mask = rule._create_mask(10)
+        self.assertEquals(mask[0], 0xff)
+        self.assertEquals(mask[1], 0xc0)
+        self.assertEquals(mask[2:], [0x00]*14)
+
+        # Mask /27 should return \xff\xff\xff\xe0...
+        mask = rule._create_mask(27)
+        self.assertEquals(mask[:3], [0xff, 0xff, 0xff])
+        self.assertEquals(mask[3], 0xe0)
+        self.assertEquals(mask[4:], [0x00]*12)
+
     def test_rule_address(self):
         # valid addresses
         rule = iptc.Rule6()


### PR DESCRIPTION
Hey

It looks like IPv6 mask fields are not being computed correctly. 
For example, `_create_mask(..., 10)` returns `[0xff, 0x03, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]`, when it should be returning `[0xff, 0xc0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]`

Steps to reproduce:
1. Create a new chain and add a rule accepting connections from `fe80::/10`
```
table = iptc.Table6('filter')
chain = table.create_chain('cX')

rule = iptc.Rule6()
rule.src = 'fe80::/10'
rule.create_target('ACCEPT')
chain.append_rule(rule)
```

2. Examine installed rules.
```
$ sudo ip6tables -nL cX
Chain cX (0 references)
target     prot opt source               destination
ACCEPT     all      fe80::/ff03::        ::/0
```

Patched version installs the rule we wanted
```
$ sudo ip6tables -nL cX
Chain cX (0 references)
target     prot opt source               destination
ACCEPT     all      fe80::/10            ::/0
```