### PR TITLE
	modified:   iptc/xtables.py

### DIFF
--- a/iptc/xtables.py
+++ b/iptc/xtables.py
@@ -804,7 +804,8 @@ if _xtables_libdir is None:
     import os.path
     for xtdir in ["/lib/xtables", "/lib64/xtables", "/usr/lib/xtables",
                   "/usr/lib/iptables", "/usr/lib64/xtables",
-                  "/usr/lib64/iptables", "/usr/local/lib/xtables", "/usr/lib/x86_64-linux-gnu/xtables"]:
+                  "/usr/lib64/iptables", "/usr/local/lib/xtables",
+                  "/usr/lib/x86_64-linux-gnu/xtables"]:
         if os.path.isdir(xtdir):
             _xtables_libdir = xtdir
             break

--- a/iptc/xtables.py
+++ b/iptc/xtables.py
@@ -804,7 +804,7 @@ if _xtables_libdir is None:
     import os.path
     for xtdir in ["/lib/xtables", "/lib64/xtables", "/usr/lib/xtables",
                   "/usr/lib/iptables", "/usr/lib64/xtables",
-                  "/usr/lib64/iptables", "/usr/local/lib/xtables"]:
+                  "/usr/lib64/iptables", "/usr/local/lib/xtables", "/usr/lib/x86_64-linux-gnu/xtables"]:
         if os.path.isdir(xtdir):
             _xtables_libdir = xtdir
             break


### PR DESCRIPTION
	Add new xtdir to fix error on Debian
I'm using Debian 9.1 amd64, and if I do not run my script by:
`XTABLES_LIBDIR=/usr/lib/x86_64-linux-gnu/xtables ./main.py`
It does not work. I added this path to xtdir list and now it does works.