### PR TITLE
Added missing table definitions to Table and Table6 classes

### DIFF
--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -1552,7 +1552,9 @@ class Table(object):
     """This is the constant for the raw table."""
     NAT = "nat"
     """This is the constant for the nat table."""
-    ALL = ["filter", "mangle", "raw", "nat"]
+    SECURITY = "security"
+    """This is the constant for the security table."""
+    ALL = ["filter", "mangle", "raw", "nat", "security"]
     """This is the constant for all tables."""
 
     _cache = dict()

--- a/iptc/ip6tc.py
+++ b/iptc/ip6tc.py
@@ -571,9 +571,11 @@ class Table6(Table):
     """This is the constant for the mangle table."""
     RAW = "raw"
     """This is the constant for the raw table."""
+    NAT = "nat"
+    """This is the constant for the nat table."""
     SECURITY = "security"
     """This is the constant for the security table."""
-    ALL = ["filter", "mangle", "raw", "security"]
+    ALL = ["filter", "mangle", "raw", "nat", "security"]
     """This is the constant for all tables."""
 
     _cache = dict()


### PR DESCRIPTION
This commit addresses the issue https://github.com/ldx/python-iptables/issues/220
