### PR TITLE
Miscellaneous usability improvements

### DIFF
--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -989,9 +989,9 @@ class Rule(object):
                 for k, v in m.get_all_parameters().items()))
         else:
             matches = 'no matches'
-        fmt = lambda ip: str(ipaddress.ip_network(ip)).replace('0.0.0.0/0', 'anywhere')
+        fmt = lambda ip: str(ipaddress.ip_interface(ip)).replace('0.0.0.0/0', 'anywhere')
         return '<Rule({}) {} -> {} {}>'.format(
-                self.target.name,
+                self.target.name if self.target else 'no target',
                 fmt(self.src),
                 fmt(self.dst),
                 matches)
@@ -1441,7 +1441,10 @@ class Chain(object):
         self.table = table
 
     def __repr__(self):
-        return '<Chain {} (policy {}, {} rules)>'.format(self.name, self.policy, len(self.rules))
+        return '<Chain {} (policy {}, {} rules)>'.format(
+                self.name,
+                self.policy.name if self.policy else 'no policy',
+                len(self.rules))
 
     def delete(self):
         """Delete chain from its table."""

--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -9,7 +9,6 @@ import socket
 import struct
 import weakref
 import functools
-import ipaddress
 
 from .util import find_library, load_kernel
 from .xtables import (XT_INV_PROTO, NFPROTO_IPV4, XTablesError, xtables,
@@ -1032,11 +1031,11 @@ class Rule(object):
                 for k, v in m.get_all_parameters().items()))
         else:
             matches = 'no matches'
-        fmt = lambda ip: str(ipaddress.ip_interface(ip)).replace('0.0.0.0/0', 'anywhere')
+
         return '<Rule({}) {} -> {} {}>'.format(
                 self.target.name if self.target else 'no target',
-                fmt(self.src),
-                fmt(self.dst),
+                self.src_numeric_mask,
+                self.dst_numeric_mask,
                 matches)
 
 

--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -1448,8 +1448,9 @@ class Chain(object):
 
     def get_policy(self):
         """Returns the policy of the chain as a Policy object."""
-        policy, counters = self.table.get_policy(self.name)
+        policy, _counters = self.table.get_policy(self.name)
         return policy
+    policy = property(get_policy, set_policy)
 
     def is_builtin(self):
         """Returns whether the chain is a built-in one."""
@@ -1807,14 +1808,15 @@ class Table(object):
             chain = self._iptc.iptc_next_chain(self._handle)
         return chains
 
-    chains = property(_get_chains)
-    """List of chains in the table."""
+    @property
+    def chains(self):
+        return {c.name: c for c in self._get_chains()}
 
     def flush(self):
         """Flush and delete all non-builtin chains the table."""
-        for chain in self.chains:
+        for chain in self.chains.values():
             chain.flush()
-        for chain in self.chains:
+        for chain in self.chains.values():
             if not self.builtin_chain(chain):
                 self.delete_chain(chain)
 

--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -8,6 +8,7 @@ import ctypes as ct
 import socket
 import struct
 import weakref
+import functools
 
 from .util import find_library, load_kernel
 from .xtables import (XT_INV_PROTO, NFPROTO_IPV4, XTablesError, xtables,
@@ -1513,6 +1514,7 @@ class Chain(object):
 
 
 def autocommit(fn):
+    @functools.wraps(fn)
     def new(*args):
         obj = args[0]
         ret = fn(*args)

--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -384,11 +384,12 @@ class IPTCModule(object):
         return self._save(name, self.rule.get_ip())
 
     def _save(self, name, ip):
-        buf = self._get_saved_buf(ip).decode()
+        buf = self._get_saved_buf(ip)
         if buf is None:
-            return None
+            return None if name else {}
         if not self._module or not self._module.save:
-            return None
+            return None if name else {}
+        buf = buf.decode()
         if name:
             return self._get_value(buf, name)
         else:
@@ -419,7 +420,7 @@ class IPTCModule(object):
         ip = self.rule.get_ip()
         buf = self._get_saved_buf(ip)
         if buf is None:
-            return params
+            return {}
         if type(buf) != str:
             # In Python3, string and bytes are different types.
             buf = buf.decode()

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     ext_modules=[Extension("libxtwrapper",
                            ["libxtwrapper/wrapper.c"])],
     test_suite="tests",
-    install_requires = [] if sys.version_info >= (3,3) else ['ipaddress'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 """python-iptables setup script"""
 
 from setuptools import setup, Extension
+import sys
 #from distutils.core import setup, Extension
 
 # make pyflakes happy
@@ -23,6 +24,7 @@ setup(
     ext_modules=[Extension("libxtwrapper",
                            ["libxtwrapper/wrapper.c"])],
     test_suite="tests",
+    install_requires = [] if sys.version_info >= (3,3) else ['ipaddress'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",

--- a/tests/test_iptc.py
+++ b/tests/test_iptc.py
@@ -239,7 +239,7 @@ class TestChain(unittest.TestCase):
             table = iptc.Table(iptc.Table.FILTER)
             table.autocommit = True
             self.assertTrue(len(table.chains) >= 3)
-            for chain in table.chains:
+            for chain in table.chains.values():
                 if chain.name not in ["INPUT", "FORWARD", "OUTPUT"]:
                     self.failIf(chain.is_builtin())
 
@@ -248,7 +248,7 @@ class TestChain(unittest.TestCase):
             table = iptc.Table(iptc.Table.NAT)
             table.autocommit = True
             self.assertTrue(len(table.chains) >= 3)
-            for chain in table.chains:
+            for chain in table.chains.values():
                 if chain.name not in ["INPUT", "PREROUTING", "POSTROUTING",
                                       "OUTPUT"]:
                     self.failIf(chain.is_builtin())
@@ -258,7 +258,7 @@ class TestChain(unittest.TestCase):
             table = iptc.Table(iptc.Table.MANGLE)
             table.autocommit = True
             self.assertTrue(len(table.chains) >= 5)
-            for chain in table.chains:
+            for chain in table.chains.values():
                 if chain.name not in ["PREROUTING", "POSTROUTING", "INPUT",
                                       "FORWARD", "OUTPUT"]:
                     self.failIf(chain.is_builtin())
@@ -268,7 +268,7 @@ class TestChain(unittest.TestCase):
             table = iptc.Table(iptc.Table.RAW)
             table.autocommit = True
             self.assertTrue(len(table.chains) >= 2)
-            for chain in table.chains:
+            for chain in table.chains.values():
                 if chain.name not in ["PREROUTING", "OUTPUT"]:
                     self.failIf(chain.is_builtin())
 
@@ -286,7 +286,8 @@ class TestChain(unittest.TestCase):
 
     def test_chain_counters(self):
         tables = self._get_tables()
-        for chain in (chain for table in tables for chain in table.chains):
+        for chain in (
+                chain for table in tables for chain in table.chains.values()):
             counters = chain.get_counters()
             fails = 0
             for x in range(3):  # try 3 times
@@ -517,27 +518,30 @@ class TestRule6(unittest.TestCase):
 
     def test_rule_iterate_filter(self):
         if is_table6_available(iptc.Table6.FILTER):
-            for r in (rule for chain in iptc.Table6(iptc.Table6.FILTER).chains
-                      for rule in chain.rules if rule):
+            for r in (rule
+                    for chain in iptc.Table6(iptc.Table6.FILTER).chains.values()
+                    for rule in chain.rules if rule):
                 pass
 
     def test_rule_iterate_raw(self):
         if is_table6_available(iptc.Table6.RAW):
-            for r in (rule for chain in iptc.Table6(iptc.Table6.RAW).chains
-                      for rule in chain.rules if rule):
+            for r in (rule
+                    for chain in iptc.Table6(iptc.Table6.RAW).chains.values()
+                    for rule in chain.rules if rule):
                 pass
 
     def test_rule_iterate_mangle(self):
         if is_table6_available(iptc.Table6.MANGLE):
-            for r in (rule for chain in iptc.Table6(iptc.Table6.MANGLE).chains
-                      for rule in chain.rules if rule):
+            for r in (rule
+                    for chain in iptc.Table6(iptc.Table6.MANGLE).chains.values()
+                    for rule in chain.rules if rule):
                 pass
 
     def test_rule_iterate_security(self):
         if is_table6_available(iptc.Table6.SECURITY):
-            for r in (rule for chain in
-                      iptc.Table6(iptc.Table6.SECURITY).chains
-                      for rule in chain.rules if rule):
+            for r in (rule
+                    for chain in iptc.Table6(iptc.Table6.SECURITY).chains.values()
+                    for rule in chain.rules if rule):
                 pass
 
     def test_rule_insert(self):
@@ -749,20 +753,23 @@ class TestRule(unittest.TestCase):
 
     def test_rule_iterate_filter(self):
         if is_table_available(iptc.Table.FILTER):
-            for r in (rule for chain in iptc.Table(iptc.Table.FILTER).chains
-                      for rule in chain.rules if rule):
+            for r in (rule
+                    for chain in iptc.Table(iptc.Table.FILTER).chains.values()
+                    for rule in chain.rules if rule):
                 pass
 
     def test_rule_iterate_nat(self):
         if is_table_available(iptc.Table.NAT):
-            for r in (rule for chain in iptc.Table(iptc.Table.NAT).chains
-                      for rule in chain.rules if rule):
+            for r in (rule
+                    for chain in iptc.Table(iptc.Table.NAT).chains.values()
+                    for rule in chain.rules if rule):
                 pass
 
     def test_rule_iterate_mangle(self):
         if is_table_available(iptc.Table.MANGLE):
-            for r in (rule for chain in iptc.Table(iptc.Table.MANGLE).chains
-                      for rule in chain.rules if rule):
+            for r in (rule
+                    for chain in iptc.Table(iptc.Table.MANGLE).chains.values()
+                    for rule in chain.rules if rule):
                 pass
 
     def test_rule_iterate_rulenum(self):


### PR DESCRIPTION
Here's three small changes I found useful. Tell me what you think.

First, using ```@functools.wraps```, docstrings and function signatures can be preserved when using ```@autocommit```. This is useful in interactive usage. This change should be backwards-compatible to at least python 2.7.

Second, I found ```Table.chains``` not very useful as a plain list, since I'd only iterate over it to get a particular chain anyway. A dict makes more sense to me here. This is obviously breaking the API, so I don't expect you to merge this right away.

Third, I wrote some nice ```__repr__```s for the most common ip4tables classes. This also is *really* useful in interactive usage, or even when just printing debug output. Be aware that as-is the formatting code pretty-prints IP adresses using the ```ipaddress``` module found in python 3.3 upwards.

Thank you for the nice module, jaseg