### PR TITLE
don't call ctypes.util.find_library on non-sonames

### DIFF
--- a/iptc/util.py
+++ b/iptc/util.py
@@ -52,6 +52,11 @@ def load_kernel(name, exc_if_failed=False):
 
 
 def _do_find_library(name):
+    if '/' in name:
+        try:
+            return ctypes.CDLL(name, mode=ctypes.RTLD_GLOBAL)
+        except Exception:
+            return None
     p = ctypes.util.find_library(name)
     if p:
         lib = ctypes.CDLL(p, mode=ctypes.RTLD_GLOBAL)


### PR DESCRIPTION
If IPTABLES_LIBDIR is given, we will pass potential paths to
_do_find_library. In this case, calling ctypes.util.find_library is not helpful,
and we should simply try to load the library directly.