### PR TITLE
Extended rule counters capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ designed to simplify the interaction with the library, for example:
     {'INPUT': [], 'OUTPUT': [], 'POSTROUTING': [], 'PREROUTING': []}
     >>> iptc.easy.dump_chain('filter', 'OUTPUT', ipv6=False)
     [{'comment': {'comment': 'DNS traffic to Google'},
+      'counters': (1, 56),
       'dst': '8.8.8.8/32',
       'protocol': 'udp',
       'target': 'ACCEPT',

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -14,6 +14,7 @@ designed to simplify the interaction with the library, for example:
     {'INPUT': [], 'OUTPUT': [], 'POSTROUTING': [], 'PREROUTING': []}
     >>> iptc.easy.dump_chain('filter', 'OUTPUT', ipv6=False)
     [{'comment': {'comment': 'DNS traffic to Google'},
+      'counters': (1, 56),
       'dst': '8.8.8.8/32',
       'protocol': 'udp',
       'target': 'ACCEPT',

--- a/iptc/easy.py
+++ b/iptc/easy.py
@@ -305,6 +305,8 @@ def encode_iptc_rule(rule_d, ipv6=False):
         try:
             if name in rule_attr:
                 continue
+            elif name == 'counters':
+                _iptc_setcounters(iptc_rule, value)
             elif name == 'target':
                 _iptc_settarget(iptc_rule, value)
             else:
@@ -353,6 +355,8 @@ def decode_iptc_rule(iptc_rule, ipv6=False):
             d['target'] = {'goto':iptc_rule.target.name}
         else:
             d['target'] = iptc_rule.target.name
+    # Get counters
+    d['counters'] = iptc_rule.counters
     # Return a filtered dictionary
     return _filter_empty_field(d)
 
@@ -387,6 +391,10 @@ def _iptc_getchain(table, chain, ipv6=False, raise_exc=True):
         return Chain(iptc_table, chain)
     except Exception as e:
         if raise_exc: raise
+
+def _iptc_setcounters(iptc_rule, value):
+    # Value is a tuple (numberOfBytes, numberOfPackets)
+    iptc_rule.counters = value
 
 def _iptc_setmatch(iptc_rule, name, value):
     # Iterate list/tuple recursively

--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -1286,6 +1286,15 @@ class Rule(object):
         counters = self.entry.counters
         return counters.pcnt, counters.bcnt
 
+    def set_counters(self, counters):
+        """This method set a tuple pair of the packet and byte counters of
+        the rule."""
+        self.entry.counters.pcnt = counters[0]
+        self.entry.counters.bcnt = counters[1]
+
+    counters = property(get_counters, set_counters)
+    """This is the packet and byte counters of the rule."""
+
     # override the following three for the IPv6 subclass
     def _entry_size(self):
         return xt_align(ct.sizeof(ipt_entry))

--- a/tests/test_iptc.py
+++ b/tests/test_iptc.py
@@ -581,6 +581,8 @@ class TestRule6(unittest.TestCase):
         target = iptc.Target(rule, "ACCEPT")
         rule.target = target
         rule_d = iptc.easy.decode_iptc_rule(rule, ipv6=True)
+        # Remove counters when comparing rules
+        rule_d.pop('counters', None)
         self.assertEqual(rule_d, {"protocol": "tcp", "src": "::1/128", "target": "ACCEPT"})
 
     def test_rule_from_dict(self):

--- a/tests/test_iptc.py
+++ b/tests/test_iptc.py
@@ -941,6 +941,8 @@ class TestRule(unittest.TestCase):
         target = iptc.Target(rule, "ACCEPT")
         rule.target = target
         rule_d = iptc.easy.decode_iptc_rule(rule)
+        # Remove counters when comparing rules
+        rule_d.pop('counters', None)
         self.assertEqual(rule_d, {"protocol": "tcp", "src": "127.0.0.1/32", "target": "ACCEPT"})
 
     def test_rule_from_dict(self):

--- a/tests/test_matches.py
+++ b/tests/test_matches.py
@@ -499,6 +499,8 @@ class TestRecentMatch(unittest.TestCase):
         }
         iptc.easy.add_rule(self.table, self.chain, rule_d)
         rule2_d = iptc.easy.get_rule(self.table, self.chain, -1)
+        # Remove counters when comparing rules
+        rule2_d.pop('counters', None)
         self.assertEqual(rule_d, rule2_d)
 
 def suite():


### PR DESCRIPTION
- Extend ip4tc.py with `set_counters()` function and make counters a property of `Rule()`
- Extend iptc.easy rule definition with a counters field, available on creation/representation: `rule_d = {'counters': (100, 100), 'dst': '1.1.1.1', 'protocol': 'icmp', 'target': ''}` 
- Counter update available via rule replacement: `iptc.easy.replace_rule(table, chain, rule_d, rule_d)`
- Update documentation