### PR TITLE
Don't set xtables_{matches,targets} to NULL.

### DIFF
--- a/iptc/xtables.py
+++ b/iptc/xtables.py
@@ -1020,10 +1020,6 @@ class xtables(object):
         if ext is not None:
             return ext
 
-        xtables._xtables_matches.value = ct.c_void_p(None).value
-        if xtables._xtables_pending_matches:
-            xtables._xtables_pending_matches.value = ct.c_void_p(None).value
-
         match = xtables._xtables_find_match(name, XTF_TRY_LOAD, None)
         if not match:
             self._try_register(name)
@@ -1044,10 +1040,6 @@ class xtables(object):
         ext = self._get_loaded_ext(name)
         if ext is not None:
             return ext
-
-        xtables._xtables_targets.value = ct.c_void_p(None).value
-        if xtables._xtables_pending_targets:
-            xtables._xtables_pending_targets.value = ct.c_void_p(None).value
 
         target = xtables._xtables_find_target(name, XTF_TRY_LOAD)
         if not target:


### PR DESCRIPTION
Protocol-independent extensions will be looked up once for each protocol
and added to the protocol-specific cache.

Fixes #282.