### PR TITLE
Add separate mechanism to load libc

### DIFF
--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -9,7 +9,7 @@ import socket
 import struct
 import weakref
 
-from .util import find_library, load_kernel
+from .util import find_library, load_kernel, find_libc
 from .xtables import (XT_INV_PROTO, NFPROTO_IPV4, XTablesError, xtables,
                       xt_align, xt_counters, xt_entry_target, xt_entry_match)
 
@@ -26,7 +26,7 @@ if not hasattr(socket, 'IPPROTO_SCTP'):
 
 _IFNAMSIZ = 16
 
-_libc = ct.CDLL("libc.so.6")
+_libc = find_libc()
 _get_errno_loc = _libc.__errno_location
 _get_errno_loc.restype = ct.POINTER(ct.c_int)
 _malloc = _libc.malloc

--- a/iptc/util.py
+++ b/iptc/util.py
@@ -109,3 +109,19 @@ def find_library(*names):
             major = int(m.group(1))
         return lib, major
     return None, None
+
+
+def find_libc():
+    lib = ctypes.util.find_library('c')
+    if lib is not None:
+        return ctypes.CDLL(lib, mode=ctypes.RTLD_GLOBAL)
+
+    libnames = ['libc.so.6', 'libc.so.0', 'libc.so']
+    for name in libnames:
+        try:
+            lib = ctypes.CDLL(name, mode=ctypes.RTLD_GLOBAL)
+            return lib
+        except:
+            pass
+
+    return None

--- a/iptc/xtables.py
+++ b/iptc/xtables.py
@@ -6,7 +6,7 @@ import sys
 import weakref
 
 from . import version
-from .util import find_library
+from .util import find_library, find_libc
 from .errors import *
 
 XT_INV_PROTO = 0x40  # invert the sense of PROTO
@@ -792,7 +792,7 @@ class xtables_target(ct.Union):
                 ("v12", _xtables_target_v12)]
 
 
-_libc, _ = find_library("c")
+_libc = find_libc()
 _optind = ct.c_long.in_dll(_libc, "optind")
 _optarg = ct.c_char_p.in_dll(_libc, "optarg")
 


### PR DESCRIPTION
I'm currently trying to fix an issue with python-iptables in [Buildroot](https://buildroot.org/) where we
encounter issues when attempting to import 0.14 due to the way dynamic libraries
are loaded. (Buildroot bug report is here: https://bugs.busybox.net/show_bug.cgi?id=12271)

First some important information for context:

- Buildroot does not support a toolchain on the target. This is a design
    decision. Due to this `ctypes.util.find_library()` does not work.
- Buildroot supports not only glibc but also uClibc and musl. These do not
    necessarily install a symlink of themselves to libc.so but do have well
    defined `soname`s.

Afaict there are 2 locations in the code where libc is loaded:

1. The first one is [here](https://github.com/ldx/python-iptables/blob/e606d413ddf7c10061f8d4556356247ffba0deaf/iptc/xtables.py#L795)
   This poses a problem for Buildroot given that by default not all libc's
   install the given symlink.
2. The second one is [here](https://github.com/ldx/python-iptables/blob/7fe9a9982bb9ddb0fa09cb12a0bc9f3d1001b382/iptc/ip4tc.py#L29)
   `libc.so.6` is the `soname` of glibc.This makes the package explicitly depend
   on glibc which would be unfortunate given that the package can also be used
   with the alternatives.

Given that the `soname` is well defined and there's already a precedent of using the `soname` directly the fix I came up with would be that finding the libc would be handled in a special case, split off from the other find_library() code i.e. a dedicated function that would explicitly check for the existence of a supported libc by `soname` in the case where `ctypes.util.find_library()` returns `None`.

The provided patch solves the issue within Buildroot for all aforementioned C libraries and should not impact systems where `ctypes.util.find_library()` works.

If this would not be an acceptable fix I'd like to at least open a discussion about how we could fix this, rather than maintain this patch out-of-tree.