### PR TITLE
Add '.so' as additional shared object suffix

### DIFF
--- a/iptc/util.py
+++ b/iptc/util.py
@@ -80,12 +80,19 @@ def _do_find_library(name):
 
 
 def _find_library(*names):
+    exts = []
     if version_info >= (3, 3):
-        ext = get_config_var("EXT_SUFFIX")
+        exts.append(get_config_var("EXT_SUFFIX"))
     else:
-        ext = get_config_var('SO')
+        exts.append(get_config_var('SO'))
+
+    if version_info >= (3, 5):
+        exts.append('.so')
+
     for name in names:
-        libnames = [name, "lib" + name, name + ext, "lib" + name + ext]
+        libnames = [name, "lib" + name]
+        for ext in exts:
+            libnames += [name + ext, "lib" + name + ext]
         libdir = os.environ.get('IPTABLES_LIBDIR', None)
         if libdir is not None:
             libdirs = libdir.split(':')


### PR DESCRIPTION
EXT_SUFFIX includes a platform information tag starting from Python 3.5 [0]
For example:

```
    >>> sysconfig.get_config_var("EXT_SUFFIX")
    '.cpython-38-aarch64-linux-gnu.so'
```

This suffix only applies to cpython extensions i.e. not to the iptables shared
objects.

Adding '.so' as an additional suffix for shared objects fixes the issue.

Fixes: Issue #301

Signed-off-by: Frank Vanbever <frank.vanbever@essensium.com>

[0]  https://docs.python.org/3/whatsnew/3.5.html#build-and-c-api-changes