### PR TITLE
fix locating _xtables_libdir with glibc >= 2.32

### DIFF
--- a/iptc/xtables.py
+++ b/iptc/xtables.py
@@ -805,7 +805,7 @@ _lib_xtables, xtables_version = find_library(_searchlib)
 _xtables_libdir = os.getenv("XTABLES_LIBDIR")
 if _xtables_libdir is None:
     import re
-    ldconfig_path_regex = re.compile('^(/.*):$')
+    ldconfig_path_regex = re.compile('^(/.*):($| \\(from)')
     import subprocess
     ldconfig = subprocess.Popen(
         ('/sbin/ldconfig', '-N', '-v'),


### PR DESCRIPTION
It appears ldconfig -v changed its output in glibc 2.32 and now looks
like this:

/lib/x86_64-linux-gnu: (from /etc/ld.so.conf.d/x86_64-linux-gnu.conf:3)
	libplds4.so -> libplds4.so
	...

This breaks the regex xtables.py is using to look for the linker search
path, so I've adjusted the regex to work with the old and new formats.