### PR TITLE
Changed regex used to find xtables libs

### DIFF
--- a/iptc/xtables.py
+++ b/iptc/xtables.py
@@ -805,7 +805,7 @@ _lib_xtables, xtables_version = find_library(_searchlib)
 _xtables_libdir = os.getenv("XTABLES_LIBDIR")
 if _xtables_libdir is None:
     import re
-    ldconfig_path_regex = re.compile('^(/.*):$')
+    ldconfig_path_regex = re.compile('^(/.*):($| \(.*\)$)')
     import subprocess
     ldconfig = subprocess.Popen(
         ('/sbin/ldconfig', '-N', '-v'),


### PR DESCRIPTION
Updated the regular expression used to identify the path where xtables library symbols are located. This change is needed due to the version of ldconfig packaged in glibc2.28 and greater changed the output that the regular expression is looking for.

Closes #329 