### PR TITLE
Speed up code for arm architecture when creating new rules

### DIFF
--- a/iptc/ip4tc.py
+++ b/iptc/ip4tc.py
@@ -40,19 +40,16 @@ _free.argtypes = [ct.POINTER(ct.c_ubyte)]
 xtables(NFPROTO_IPV4)
 
 
-exist_table_names = dict() # Dictionary to check faster if table is available
-
 def is_table_available(name):
-    global exist_table_names
     try:
-        if name in exist_table_names:
-            return exist_table_names[name]
+        if name in Table.existing_table_names:
+            return Table.existing_table_names[name]
         Table(name)
-        exist_table_names[name] = True
+        Table.existing_table_names[name] = True
         return True
     except IPTCError:
         pass
-    exist_table_names[name] = False
+    Table.existing_table_names[name] = False
     return False
 
 
@@ -1586,6 +1583,8 @@ class Table(object):
     """This is the constant for all tables."""
 
     _cache = dict()
+    existing_table_names = dict()
+    """Dictionary to check faster if a table is available."""
 
     def __new__(cls, name, autocommit=None):
         obj = Table._cache.get(name, None)

--- a/iptc/ip6tc.py
+++ b/iptc/ip6tc.py
@@ -17,12 +17,19 @@ except:
 _IFNAMSIZ = 16
 
 
+exist_table6_names = dict() # Dictionary to check faster if table is available
+
 def is_table6_available(name):
+    global exist_table6_names
     try:
+        if name in exist_table6_names:
+            return exist_table6_names[name]
         Table6(name)
+        exist_table6_names[name] = True
         return True
     except IPTCError:
         pass
+    exist_table6_names[name] = False
     return False
 
 

--- a/iptc/ip6tc.py
+++ b/iptc/ip6tc.py
@@ -17,19 +17,16 @@ except:
 _IFNAMSIZ = 16
 
 
-exist_table6_names = dict() # Dictionary to check faster if table is available
-
 def is_table6_available(name):
-    global exist_table6_names
     try:
-        if name in exist_table6_names:
-            return exist_table6_names[name]
+        if name in Table6.existing_table_names:
+            return Table6.existing_table_names[name]
         Table6(name)
-        exist_table6_names[name] = True
+        Table6.existing_table_names[name] = True
         return True
     except IPTCError:
         pass
-    exist_table6_names[name] = False
+    Table6.existing_table_names[name] = False
     return False
 
 
@@ -579,6 +576,8 @@ class Table6(Table):
     """This is the constant for all tables."""
 
     _cache = dict()
+    existing_table_names = dict()
+    """Dictionary to check faster if a table is available."""
 
     def __new__(cls, name, autocommit=None):
         obj = Table6._cache.get(name, None)


### PR DESCRIPTION
Since the arm architecture is slow to always lookup the tables, the creation of many rules with standard targets like Accept or Reject can slow down the creation of firewall rules. For this reason, a dictionary is used to check available tables and standard targets are not check if they are a chain.
This code can halve the execution time on an Arm architectures if many firewall rules are created.