### PR TITLE
fix(ip6tc): ipv6 interface name with 15 chars is too big

### DIFF
--- a/iptc/ip6tc.py
+++ b/iptc/ip6tc.py
@@ -412,22 +412,19 @@ class Rule6(Rule):
     def get_in_interface(self):
         intf = ""
         if self.entry.ipv6.invflags & ip6t_ip6.IP6T_INV_VIA_IN:
-            intf = "".join(["!", intf])
-        iface = bytearray(_IFNAMSIZ)
-        iface[:len(self.entry.ipv6.iniface)] = self.entry.ipv6.iniface
-        mask = bytearray(_IFNAMSIZ)
-        mask[:len(self.entry.ipv6.iniface_mask)] = self.entry.ipv6.iniface_mask
-        if mask[0] == 0:
+            intf = "!"
+
+        iface = self.entry.ipv6.iniface.decode()
+        mask = self.entry.ipv6.iniface_mask
+
+        if len(mask) == 0:
             return None
-        for i in range(_IFNAMSIZ):
-            if mask[i] != 0:
-                intf = "".join([intf, chr(iface[i])])
-            else:
-                if iface[i - 1] != 0:
-                    intf = "".join([intf, "+"])
-                else:
-                    intf = intf[:-1]
-                break
+
+        intf += iface
+        if len(iface) == len(mask):
+            intf += '+'
+        intf = intf[:_IFNAMSIZ]
+
         return intf
 
     def set_in_interface(self, intf):
@@ -456,23 +453,19 @@ class Rule6(Rule):
     def get_out_interface(self):
         intf = ""
         if self.entry.ipv6.invflags & ip6t_ip6.IP6T_INV_VIA_OUT:
-            intf = "".join(["!", intf])
-        iface = bytearray(_IFNAMSIZ)
-        iface[:len(self.entry.ipv6.outiface)] = self.entry.ipv6.outiface
-        mask = bytearray(_IFNAMSIZ)
-        mask[:len(self.entry.ipv6.outiface_mask)] = \
-            self.entry.ipv6.outiface_mask
-        if mask[0] == 0:
+            intf = "!"
+
+        iface = self.entry.ipv6.outiface.decode()
+        mask = self.entry.ipv6.outiface_mask
+
+        if len(mask) == 0:
             return None
-        for i in range(_IFNAMSIZ):
-            if mask[i] != 0:
-                intf = "".join([intf, chr(iface[i])])
-            else:
-                if iface[i - 1] != 0:
-                    intf = "".join([intf, "+"])
-                else:
-                    intf = intf[:-1]
-                break
+
+        intf += iface
+        if len(iface) == len(mask):
+            intf += '+'
+        intf = intf[:_IFNAMSIZ]
+
         return intf
 
     def set_out_interface(self, intf):

--- a/tests/test_iptc.py
+++ b/tests/test_iptc.py
@@ -423,7 +423,9 @@ class TestRule6(unittest.TestCase):
     def test_rule_interface(self):
         # valid interfaces
         rule = iptc.Rule6()
-        for intf in ["eth0", "eth+", "ip6tnl1", "ip6tnl+", "!ppp0", "!ppp+"]:
+
+        max_length_valid_interface_name = "0123456789abcde"
+        for intf in ["eth0", "eth+", "ip6tnl1", "ip6tnl+", "!ppp0", "!ppp+", max_length_valid_interface_name]:
             rule.in_interface = intf
             self.assertEquals(intf, rule.in_interface)
             rule.out_interface = intf


### PR DESCRIPTION
```
File "/home/zn-admin/.zn-internal/venv3/lib/python3.8/site-packages/iptc/easy.py", line 303, in encode_iptc_rule
    setattr(iptc_rule, name.replace('-', '_'), rule_d[name])
  File "/home/zn-admin/.zn-internal/venv3/lib/python3.8/site-packages/iptc/ip6tc.py", line 486, in set_out_interface
    raise ValueError("interface name %s too long" % (intf))
ValueError: interface name br-13786b5c3131\x00  too long

```

IPv4 and IPv6 code for getting in/out interface name is different, while IPv6 contained the following bug if the interface name is 15 characters:
`for i in range(_IFNAMSIZ):` will never run the `else` section which deletes the last null character using `  intf = intf[:-1]
`if the interface name is 15 chars. 

I aligned the logic to use the same one as ipv4, since both function are doing the same thing, just in a different way

before the fix:
![image](https://github.com/user-attachments/assets/fd7da417-606b-4ae9-b917-f24596f4fe91)
after the fix:
![image](https://github.com/user-attachments/assets/0768ea50-30f4-45ca-89aa-3b9dac5a96ce)
