### PR TITLE
Make python-iptables compatible with python 3.12

### DIFF
--- a/iptc/util.py
+++ b/iptc/util.py
@@ -3,7 +3,6 @@ import os
 import sys
 import ctypes
 import ctypes.util
-from distutils.sysconfig import get_python_lib
 from itertools import product
 from subprocess import Popen, PIPE
 from sys import version_info
@@ -14,6 +13,12 @@ except ImportError:
         if name == 'SO':
             return '.so'
         raise Exception('Not implemented')
+try:
+    from distutils.sysconfig import get_python_lib
+except ModuleNotFoundError:
+    import sysconfig
+    def get_python_lib():
+        return sysconfig.get_path("purelib")
 
 
 def _insert_ko(modprobe, modname):

--- a/iptc/version.py
+++ b/iptc/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 __pkgname__ = "python-iptables"
-__version__ = "1.0.2-dev"
+__version__ = "1.1.0"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 """python-iptables setup script"""
 
 from setuptools import setup, Extension
-#from distutils.core import setup, Extension
 
 # make pyflakes happy
 __pkgname__ = None


### PR DESCRIPTION
Addresses `ModuleNotFound` error described in https://github.com/ldx/python-iptables/issues/308 due to https://peps.python.org/pep-0632/
`sysconfig` was added in python 3.2 but setup in this repo still specifies support for python 2 (and not specific python3 version) so we still first attempt to import `distutils` and if that fails use `sysconfig`.